### PR TITLE
✨ Allow to use secure element while doing http authentication

### DIFF
--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -594,6 +594,10 @@ esp_http_client_handle_t esp_http_client_init(const esp_http_client_config_t *co
         esp_transport_ssl_set_cert_data(ssl, config->cert_pem, strlen(config->cert_pem));
     }
 
+    if (config->use_secure_element) {
+        esp_transport_ssl_use_secure_element(ssl);
+    }
+
     if (config->client_cert_pem) {
         esp_transport_ssl_set_client_cert_data(ssl, config->client_cert_pem, strlen(config->client_cert_pem));
     }

--- a/components/esp_http_client/include/esp_http_client.h
+++ b/components/esp_http_client/include/esp_http_client.h
@@ -135,6 +135,7 @@ typedef struct {
     int                         keep_alive_idle;     /*!< Keep-alive idle time. Default is 5 (second) */
     int                         keep_alive_interval; /*!< Keep-alive interval time. Default is 5 (second) */
     int                         keep_alive_count;    /*!< Keep-alive packet retry send count. Default is 3 counts */
+    bool                        use_secure_element;  /*!< Enable this option to use secure element or not */
 } esp_http_client_config_t;
 
 /**


### PR DESCRIPTION
This fix greatly simplify the use of the secure element while doing http authentication. 
Esp-idf guys will merge a similar patch but on higher version of esp-idf (> v4.3).
See this issue https://github.com/espressif/esp-idf/issues/10071 we previously risen.